### PR TITLE
add readthedocs configuration file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,17 @@
+# Configuration on how ReadTheDocs (RTD) builds our documentation
+# ref: https://readthedocs.org/projects/jupyterhub-pytest-plugin/
+# ref: https://docs.readthedocs.io/en/stable/config-file/v2.html
+#
+version: 2
+
+sphinx:
+  configuration: docs/source/conf.py
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+python:
+  install:
+    - requirements: docs/requirements.txt


### PR DESCRIPTION
* created the readthedocs configuration file using the [JupyterHub python repo template](https://github.com/jupyterhub/jupyterhub-python-repo-template/blob/main/.readthedocs.yaml) as reference

Closes #6 